### PR TITLE
Obvious bug in resize.js and rotate.js

### DIFF
--- a/media/plg_media-action_rotate/js/rotate.js
+++ b/media/plg_media-action_rotate/js/rotate.js
@@ -33,7 +33,8 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
 		ctx.drawImage(image, -image.width / 2, -image.height / 2);
 
 		// The format
-		var format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
+		var format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
+
 
 		// The quality
 		var quality = document.getElementById('jform_rotate_quality').value;


### PR DESCRIPTION
Use the same code as in crop.js for the file format.
myimage.jpeg becomes png encoded
I couldn't find out if this has any consequences but it sure could.

